### PR TITLE
Release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
 [[package]]
 name = "configs"
 version = "0.0.1"
-source = "git+ssh://git@github.com/ruskit/configs.git?rev=v0.0.0#32539681f7f6fe0daebd1260dcbc55618e06d278"
+source = "git+ssh://git@github.com/ruskit/configs.git?rev=v0.0.1#4e4191e7fc41f37c0dc889d5c249361629475610"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ otlp = ["dep:opentelemetry-otlp"]
 stdout = ["dep:opentelemetry-stdout"]
 
 [dependencies]
-configs = { git = "ssh://git@github.com/ruskit/configs.git", rev = "v0.0.0" }
+configs = { git = "ssh://git@github.com/ruskit/configs.git", rev = "v0.0.1" }
 
 opentelemetry = { version = "0.29.1" }
 opentelemetry_sdk = { version = "0.29.0", features = ["rt-tokio"]}

--- a/src/exporters/otlp_grpc.rs
+++ b/src/exporters/otlp_grpc.rs
@@ -10,10 +10,9 @@
 
 use crate::{errors::TracesError, get_sampler};
 use configs::{Configs, DynamicConfigs};
-use opentelemetry::{KeyValue, global, propagation::TextMapCompositePropagator};
+use opentelemetry::KeyValue;
 use opentelemetry_otlp::{Compression, Protocol, SpanExporter, WithExportConfig, WithTonicConfig};
 use opentelemetry_sdk::{
-    propagation::{BaggagePropagator, TraceContextPropagator},
     resource::Resource,
     trace::{RandomIdGenerator, SdkTracerProvider, TracerProviderBuilder},
 };
@@ -106,12 +105,6 @@ where
         )
         .with_batch_exporter(exporter)
         .build();
-
-    global::set_tracer_provider(provider);
-    global::set_text_map_propagator(TextMapCompositePropagator::new(vec![
-        Box::new(TraceContextPropagator::new()),
-        Box::new(BaggagePropagator::new()),
-    ]));
 
     debug!("traces::install otlp tracer installed");
 

--- a/src/exporters/stdout.rs
+++ b/src/exporters/stdout.rs
@@ -10,10 +10,9 @@
 
 use crate::{errors::TracesError, get_sampler};
 use configs::{Configs, DynamicConfigs};
-use opentelemetry::{KeyValue, global, propagation::TextMapCompositePropagator};
+use opentelemetry::KeyValue;
 use opentelemetry_sdk::{
     Resource,
-    propagation::{BaggagePropagator, TraceContextPropagator},
     trace::{RandomIdGenerator, SdkTracerProvider, TracerProviderBuilder},
 };
 use tracing::debug;
@@ -67,13 +66,6 @@ where
         )
         .with_simple_exporter(exporter)
         .build();
-
-    global::set_tracer_provider(provider);
-
-    global::set_text_map_propagator(TextMapCompositePropagator::new(vec![
-        Box::new(TraceContextPropagator::new()),
-        Box::new(BaggagePropagator::new()),
-    ]));
 
     debug!("traces::install stdout tracer installed");
 


### PR DESCRIPTION
This pull request refactors the OpenTelemetry tracing setup by centralizing the configuration of the global tracer provider and text map propagator. It also updates the `configs` dependency to a newer version. The most important changes include removing redundant propagator setup in individual exporters and consolidating it in the `provider` module.

### Dependency Update:
* Updated the `configs` dependency in `Cargo.toml` to version `v0.0.1` to use the latest configurations.

### Refactoring of Tracing Setup:
* Removed the setup of `global::set_tracer_provider` and `global::set_text_map_propagator` in `src/exporters/otlp_grpc.rs` and `src/exporters/stdout.rs`, simplifying the exporters. [[1]](diffhunk://#diff-33107121801ef5f44f7d5d46df1ee317b330b70cb3be4f6f5675a5e21a0e0389L110-L115) [[2]](diffhunk://#diff-685df37a745c72da524dc20f01bdc5d2e391107ddc1392c7d0b547f02935ca00L71-L77)
* Centralized the configuration of the global tracer provider and text map propagator in `src/provider.rs` for both `stdout` and `otlp_grpc` exporters. This ensures consistent setup across exporters. [[1]](diffhunk://#diff-ac2ac359957203dd5b34f40737b4580ff70e166d887226350d589f985f86a375L59-R69) [[2]](diffhunk://#diff-ac2ac359957203dd5b34f40737b4580ff70e166d887226350d589f985f86a375L71-R87)

### Code Cleanup:
* Removed unused imports of `BaggagePropagator` and `TraceContextPropagator` in `src/exporters/otlp_grpc.rs` and `src/exporters/stdout.rs`. [[1]](diffhunk://#diff-33107121801ef5f44f7d5d46df1ee317b330b70cb3be4f6f5675a5e21a0e0389L13-L16) [[2]](diffhunk://#diff-685df37a745c72da524dc20f01bdc5d2e391107ddc1392c7d0b547f02935ca00L13-L16)
* Added necessary imports for propagators in `src/provider.rs` to support the centralized configuration.…provider setup in exporters